### PR TITLE
swap latitude and longitude order

### DIFF
--- a/ogr2poly.py
+++ b/ogr2poly.py
@@ -139,7 +139,7 @@ def createPolys(inOgr, options):
                 # output all points in the ring
                 for j in range(0, ring.GetPointCount()):
                     (x, y, z) = ring.GetPoint(j)
-                    print('   %.6E   %.6E' % (x, y))
+                    print('   %.6E   %.6E' % (y, x))
                 print('END')
         print('END')
     return True


### PR DESCRIPTION
Hi, and thanks for this!

We ran into some issues when converting GeoJSON files to Poly using this script. 
According to the [OSM wiki page](https://wiki.openstreetmap.org/wiki/Osmosis/Polygon_Filter_File_Format) the order must be `longitude`, `latitude`.

> The third and subsequent lines in the section contain the coordinates of the polygon points in the order longitude, latitude, separated by whitespace. 

After some debugging I figured out that in the generated Poly files the order was `latitude`, `longitude`. After I swapped `x` and `y` everything worked.

Maybe this is useful for anyone using this script.